### PR TITLE
feat: make ship immortal to boulders

### DIFF
--- a/game.js
+++ b/game.js
@@ -436,13 +436,13 @@ Ship = function () {
   };
 
   this.collision = function (other) {
-    SFX.explosion();
-    Game.explosionAt(other.x, other.y);
-    Game.FSM.state = 'player_died';
-    this.visible = false;
-    this.currentNode.leave(this);
-    this.currentNode = null;
-    Game.lives--;
+    // SFX.explosion();
+    // Game.explosionAt(other.x, other.y);
+    // Game.FSM.state = 'player_died';
+    // this.visible = false;
+    // this.currentNode.leave(this);
+    // this.currentNode = null;
+    // Game.lives--;
   };
 
 };


### PR DESCRIPTION
Made ship immortal by commenting out any within the collision handler which indicates a change of status of the ship.
Boulders now break when in contact with the ship.
Lives are not lost nor gained meaning any kind of other way of damaging the ship other than collisions will likely kill it.